### PR TITLE
Added printDeadLocks(OutputStream writer, int maxDepth) method.

### DIFF
--- a/src/main/java/com/google/code/tempusfugit/concurrency/ThreadDump.java
+++ b/src/main/java/com/google/code/tempusfugit/concurrency/ThreadDump.java
@@ -44,10 +44,15 @@ public class ThreadDump {
 
             private void print(Thread thread, StackTraceElement[] stackTraceElements) throws IOException {
                 writeln(writer, format("%sThread %s@%d: (state = %s)", lineSeparator, thread.getName(), thread.getId(), thread.getState()));
-                for (StackTraceElement stackTraceElement : stackTraceElements)
-                    writeln(writer, format(" - %s", stackTraceElement.toString()));
+                printStackTrace (writer, stackTraceElements);
             }
+
         };
+    }
+
+    static void printStackTrace (final OutputStream writer, StackTraceElement[] stackTraceElements) throws IOException {
+        for (StackTraceElement stackTraceElement : stackTraceElements)
+            writeln(writer, format(" - %s", stackTraceElement.toString()));
     }
 
     private static void writeln(OutputStream writer, String string) throws IOException {


### PR DESCRIPTION
Hello,

I've overloaded the printDeadLocks(...) method.

The new printDeadLocks (OutputStream writer, int maxDepth) prints stack traces for the deadlocked threads.
The default method (without maxDepth argument) doesn't print the stack traces.

Regards,

Florent
