### PR TITLE
Avoid re-running `@Ignored` tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.10</version>
+            <version>4.12</version>
         </dependency>
         <!-- test -->
         <dependency>

--- a/src/main/java/com/google/code/tempusfugit/concurrency/IntermittentTestRunner.java
+++ b/src/main/java/com/google/code/tempusfugit/concurrency/IntermittentTestRunner.java
@@ -37,6 +37,8 @@ public class IntermittentTestRunner extends BlockJUnit4ClassRunner {
     }
 
     private int repeatCount(FrameworkMethod method) {
+        if (isIgnored(method))
+            return 1;
         if (intermittent(type))
             return repetition(type);
         if (intermittent(method))

--- a/tempus-fugit.iml
+++ b/tempus-fugit.iml
@@ -11,7 +11,7 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
-    <orderEntry type="library" name="Maven: junit:junit:4.10" level="project" />
+    <orderEntry type="library" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.jmock:jmock-junit4:2.6.0" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.jmock:jmock:2.6.0" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.jmock:jmock-legacy:2.6.0" level="project" />

--- a/tempus-fugit.ipr
+++ b/tempus-fugit.ipr
@@ -321,15 +321,15 @@
         <root url="jar://$MAVEN_REPOSITORY$/cglib/cglib-nodep/2.1_3/cglib-nodep-2.1_3-sources.jar!/" />
       </SOURCES>
     </library>
-    <library name="Maven: junit:junit:4.10">
+    <library name="Maven: junit:junit:4.12">
       <CLASSES>
-        <root url="jar://$MAVEN_REPOSITORY$/junit/junit/4.10/junit-4.10.jar!/" />
+        <root url="jar://$MAVEN_REPOSITORY$/junit/junit/4.12/junit-4.12.jar!/" />
       </CLASSES>
       <JAVADOC>
-        <root url="jar://$MAVEN_REPOSITORY$/junit/junit/4.10/junit-4.10-javadoc.jar!/" />
+        <root url="jar://$MAVEN_REPOSITORY$/junit/junit/4.12/junit-4.12-javadoc.jar!/" />
       </JAVADOC>
       <SOURCES>
-        <root url="jar://$MAVEN_REPOSITORY$/junit/junit/4.10/junit-4.10-sources.jar!/" />
+        <root url="jar://$MAVEN_REPOSITORY$/junit/junit/4.12/junit-4.12-sources.jar!/" />
       </SOURCES>
     </library>
     <library name="Maven: org.hamcrest:hamcrest-core:1.3">


### PR DESCRIPTION
With this change, the repeat count of 1 is always returned for test methods annotated with `@Ignore`, regardless of what `@Intermittent` specifies.